### PR TITLE
Avoid repeats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+geopandas
+pyarrow
+requests


### PR DESCRIPTION
there was an issue where trimming would result in the same point repeated sequentially.

for example if you have two points
`[[-85.12345678, 43],[-85.1234567800001, 43]]`

when they are trimmed they will be equal 
`[[-85.123456, 43],[-85.123456, 43]]`

That's causing issues with a downstream project

The solution is basically to add in an if statement before adding the trimmed point to the output coordinates array and only adding it if it's not the same as the last coordinate on the array.